### PR TITLE
Add script to reset changes to specified branch

### DIFF
--- a/reset-to-branch.sh
+++ b/reset-to-branch.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Script to reset changes to 'main' or 'original' branch
+
+set -e
+
+TARGET_BRANCH="${1:-main}"
+
+# Validate branch name
+if [[ "$TARGET_BRANCH" != "main" && "$TARGET_BRANCH" != "original" ]]; then
+    echo "Error: Invalid branch. Use 'main' or 'original'"
+    echo "Usage: $0 [main|original]"
+    exit 1
+fi
+
+# Check if we're in a git repository
+if ! git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+    echo "Error: Not in a git repository"
+    exit 1
+fi
+
+# Check if target branch exists
+if ! git rev-parse --verify "$TARGET_BRANCH" > /dev/null 2>&1; then
+    echo "Error: Branch '$TARGET_BRANCH' does not exist"
+    exit 1
+fi
+
+echo "This will reset all changes to branch '$TARGET_BRANCH'"
+echo "WARNING: All uncommitted changes will be lost!"
+read -p "Are you sure? (y/N): " confirm
+
+if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+    echo "Aborted."
+    exit 0
+fi
+
+echo "Resetting to '$TARGET_BRANCH'..."
+git reset --hard "$TARGET_BRANCH"
+git clean -fd
+
+echo "Done. Working directory reset to '$TARGET_BRANCH'"


### PR DESCRIPTION
This script resets the working directory to the specified branch, either 'main' or 'original', and warns about losing uncommitted changes.

# Changes

Please provide a brief description of the changes here.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
